### PR TITLE
[API]: Add API to retrive files from .cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,30 +18,19 @@ The installation can be done manually on Linux, MacOS, Android (Requires Termux)
 
 - First, download the proper executable for your platform from the [Releases page](https://github.com/gamemaker1/dabbu-server/releases). (Caution: releases may not work on certain versions of Android, depending on the manafacturer and version.)
 
-- Open terminal/command prompt and run the following command:
+- On Windows, simply double click on the file to run it. 
 
-  ```sh
-  $ /path/to/executable start
-  ```
-
-  If I have downloaded the executable to my downloads folder, the command would be:
-
-  - On Windows:
-    
-    ```bat
-    $ C:\Users\<user name>\Downloads\dabbu-server-win.exe start
-    ```
-    
+- On Linux/MacOS, run the following command in a terminal (assuming you have downloaded the executable to your Downloads folder):
   - On MacOS:
-    
+
     ```sh
-    $ ~/Downloads/dabbu-server-macos start
+    $ ~/Downloads/dabbu-server-macos
     ```
-    
+
   - On Linux:
-    
+  
     ```sh
-    $ ~/Downloads/dabbu-server-linux start
+    $ ~/Downloads/dabbu-server-linux
     ```
 
 - Your server is now running! To check, go to http://localhost:8080/. You will see the text `Dabbu Server running on port 8080` on the page. If not, try running the server again or check if you have missed a step. If the problem persists, post a message on [Github discussions](https://github.com/gamemaker1/dabbu-server/discussions/categories/q-a) asking for help. We'll only be glad to help you :)

--- a/docs/APIs.md
+++ b/docs/APIs.md
@@ -112,3 +112,15 @@ Please URL encode all params, especially file and folder paths while sending req
   - `404`: The file was not found - `notFound`
   - `500`: Internal server error, used if an uncaught exception appears - `internalServerError`
   - `503`: Provider not available - `providerNotFound`
+
+### **Download a file from cache**
+#### **GET**: `/cache/:filePath`
+- Request parameters: [Compulsory]
+  - `filePath`: Path to the file - `string`
+- Request body: [Empty]
+- Response:
+  - `res`: Download of the file's contents
+- Errors:
+  - `400`: The file path was incorrect - `malformedUrl`
+  - `404`: The file was not found - `notFound`
+  - `500`: Internal server error, used if an uncaught exception appears - `internalServerError`

--- a/docs/APIs.md
+++ b/docs/APIs.md
@@ -86,7 +86,7 @@ Please URL encode all params, especially file and folder paths while sending req
   - `fileName`: Name of the file - `string`
 - Request body: [Posted as multipart form data]
   - The request body may contain any fields that the provider requires to execute the request
-  - `content`: The file content - `file-data` [Compulsory]
+  - `content`: The file content - `file-data` [Optional]
   - `name`: The name of the file - `string` [Optional]
   - `path`: The path to the folder in which the file resides - `string` [Optional]
   - `createdAtTime`: Time the file was created (may not be supported by all providers) - `timestamp` [Optional]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dabbu-server",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -46,10 +46,109 @@
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
       "integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY="
     },
+    "archiver": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.2.0.tgz",
+      "integrity": "sha512-QEAKlgQuAtUxKeZB9w5/ggKXh21bZS+dzzuQ0RPBC20qtDCbTyzqmisoeJP46MP39fg4B4IcyvR+yeyEBdblsQ==",
+      "dev": true,
+      "requires": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.0",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.0.0",
+        "tar-stream": "^2.1.4",
+        "zip-stream": "^4.0.4"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
+    "archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "async": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+      "dev": true
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -63,6 +162,63 @@
       "dev": true,
       "requires": {
         "follow-redirects": "^1.10.0"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
       }
     },
     "body-parser": {
@@ -82,6 +238,32 @@
         "type-is": "~1.6.17"
       }
     },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -100,6 +282,52 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+    },
+    "compress-commons": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
+      "integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -169,6 +397,54 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "crc-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
+      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+      "dev": true,
+      "requires": {
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
+      }
+    },
+    "crc32-stream": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.2.tgz",
+      "integrity": "sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==",
+      "dev": true,
+      "requires": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -212,6 +488,15 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -221,6 +506,12 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
+      "dev": true
     },
     "express": {
       "version": "4.17.1",
@@ -301,6 +592,12 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
     "fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -310,6 +607,26 @@
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -343,6 +660,16 @@
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
     },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -372,6 +699,77 @@
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       }
+    },
+    "lazystream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+      "dev": true
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -404,6 +802,15 @@
       "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
       "requires": {
         "mime-db": "1.45.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -444,6 +851,12 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -457,10 +870,25 @@
         "ee-first": "1.1.1"
       }
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -471,6 +899,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.3.tgz",
       "integrity": "sha512-mpAcysyRJxmICBcBa5IXH7SZPvWkcghm6Fk8RekoS3v+BpbSzlZzuWbMx+GXrlUwESi9qHar4nVEZNMKylIHvg==",
+      "dev": true
+    },
+    "printj": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
       "dev": true
     },
     "process-nextick-args": {
@@ -557,6 +991,15 @@
         }
       }
     },
+    "readdir-glob": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.1.tgz",
+      "integrity": "sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -636,6 +1079,47 @@
         "peek-readable": "^3.1.3"
       }
     },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -708,10 +1192,55 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
+    "zip-stream": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
+      "integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
+      "dev": true,
+      "requires": {
+        "archiver-utils": "^2.1.0",
+        "compress-commons": "^4.0.2",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   },
   "scripts": {
     "start": "node src/server.js start",
-    "clean": "rm -r dist && mkdir dist",
+    "clean": "rm -r dist; mkdir dist",
     "prebuild": "npm run clean",
     "build": "pkg --output dist/dabbu-server .",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\"; exit 1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dabbu-server",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "description": "A unified API interface to access all your data online",
   "directories": {
     "doc": "docs"
@@ -28,6 +28,7 @@
     "multer": "^1.4.2"
   },
   "devDependencies": {
+    "archiver": "^5.2.0",
     "axios": "^0.21.1",
     "file-type": "16.2.0",
     "turndown": "^7.0.0"

--- a/src/errors.js
+++ b/src/errors.js
@@ -21,7 +21,7 @@
 exports.GeneralError = class GeneralError extends Error {
   // It must have an HTTP response code, a user-friendly message and a computer-friendly reason
   constructor(code, message, reason) {
-    super();
+    super()
     this.code = code
     this.message = message
     this.reason = reason
@@ -69,7 +69,7 @@ exports.ProviderNotEnabledError = class ProviderNotEnabledError extends this.Gen
 
 // The custom error handler we use on the server
 exports.errorHandler = (err, req, res, next) => {
-  if (err instanceof GeneralError) {
+  if (err instanceof this.GeneralError) {
     // If it is a custom error, return the code, message and reason accordingly
     return res.status(err.code).json({
       code: err.code,
@@ -92,7 +92,7 @@ exports.errorHandler = (err, req, res, next) => {
     } else if (err.isAxiosError) {
       console.error(err.response.data)
       // If it's an axios error, return the status code and the error
-      const errorMessage = err.response.data && err.response.data.error && err.response.data.error.message ? err.response.data.error.message : "unknown error"
+      const errorMessage = err.response.data && err.response.data.error && err.response.data.error.message ? err.response.data.error.message : "Unknown error"
       const errorReason = err.response.data && err.response.data.error && err.response.data.error.reason ? err.response.data.error.reason : err.response.data.error.code || "unknownReason"
       console.error(`${err.response.status} (${err.response.statusText}): ${errorMessage}`)
       return res.status(err.response.status).json({

--- a/src/modules/google_drive.js
+++ b/src/modules/google_drive.js
@@ -252,7 +252,7 @@ class GoogleDriveDataProvider extends Provider {
     let {compareWith, operator, value, orderBy, direction, exportType} = queries
 
     // Don't allow relative paths, let clients do th
-    if (folderPath.indexOf("..") !== -1) {
+    if (folderPath.indexOf("/..") !== -1) {
       throw new BadRequestError(`Folder paths must not contain relative paths`)
     }
 
@@ -366,7 +366,7 @@ class GoogleDriveDataProvider extends Provider {
     const isShared = diskPath(params["folderPath"]).startsWith("/Shared") || diskPath(params["folderPath"]).startsWith("Shared")
 
     // Don't allow relative paths, let clients do that
-    if ([folderPath, fileName].join("/").indexOf("..") !== -1) {
+    if ([folderPath, fileName].join("/").indexOf("/..") !== -1) {
       throw new BadRequestError(`Folder paths must not contain relative paths`)
     }
     
@@ -459,7 +459,7 @@ class GoogleDriveDataProvider extends Provider {
     const exportType = body["exportType"]
 
     // Don't allow relative paths, let clients do that
-    if ([folderPath, fileName].join("/").indexOf("..") !== -1) {
+    if ([folderPath, fileName].join("/").indexOf("/..") !== -1) {
       throw new BadRequestError(`Folder paths must not contain relative paths`)
     }
 
@@ -572,7 +572,7 @@ class GoogleDriveDataProvider extends Provider {
     let fileName = params["fileName"]
 
     // Don't allow relative paths, let clients do that
-    if ([folderPath, fileName].join("/").indexOf("..") !== -1) {
+    if ([folderPath, fileName].join("/").indexOf("/..") !== -1) {
       throw new BadRequestError(`Folder paths must not contain relative paths`)
     }
 
@@ -599,7 +599,7 @@ class GoogleDriveDataProvider extends Provider {
     }
     if (body["path"]) {
       // Don't allow relative paths, let clients do that
-      if (body["path"].indexOf("..") !== -1) {
+      if (body["path"].indexOf("/..") !== -1) {
         throw new BadRequestError(`Folder paths must not contain relative paths`)
       }
       // Get the new folder ID
@@ -679,7 +679,7 @@ class GoogleDriveDataProvider extends Provider {
     const fileName = params["fileName"]
 
     // Don't allow relative paths, let clients do that
-    if (folderPath.indexOf("..") !== -1) {
+    if (folderPath.indexOf("/..") !== -1) {
       throw new BadRequestError(`Folder paths must not contain relative paths`)
     }
 

--- a/src/modules/hard_drive.js
+++ b/src/modules/hard_drive.js
@@ -46,11 +46,11 @@ class HardDriveDataProvider extends Provider {
       throw new MissingParamError("Expected base path to be part of request body")
     }
     // Get the folder path in the URL
-    const folderPath = params["folderPath"]
+    const folderPath = params["folderPath"].replace(basePath, "")
     let {compareWith, operator, value, orderBy, direction} = queries
 
     // Don't allow relative paths, let clients do that
-    if ([basePath, folderPath].join("/").indexOf("..") !== -1) {
+    if ([basePath, folderPath].join("/").indexOf("/..") !== -1) {
       throw new BadRequestError(`Folder paths must not contain relative paths`)
     }
 
@@ -101,12 +101,12 @@ class HardDriveDataProvider extends Provider {
     // Get the base path provided in the request body
     const basePath = body["base_path"]
     // Get the folder path in the URL
-    const folderPath = params["folderPath"]
+    const folderPath = params["folderPath"].replace(basePath, "")
     // Get the file name in the URL
     const fileName = params["fileName"]
 
     // Don't allow relative paths, let clients do that
-    if ([basePath, folderPath].join("/").indexOf("..") !== -1) {
+    if ([basePath, folderPath].join("/").indexOf("/..") !== -1) {
       throw new BadRequestError(`Folder paths must not contain relative paths`)
     }
 
@@ -139,12 +139,12 @@ class HardDriveDataProvider extends Provider {
     // Get the base path provided in the request body
     const basePath = body["base_path"]
     // Get the folder path in the URL
-    const folderPath = params["folderPath"]
+    const folderPath = params["folderPath"].replace(basePath, "")
     // Get the file name in the URL
     const fileName = params["fileName"]
 
     // Don't allow relative paths, let clients do that
-    if ([basePath, folderPath].join("/").indexOf("..") !== -1) {
+    if ([basePath, folderPath].join("/").indexOf("/..") !== -1) {
       throw new BadRequestError(`Folder paths must not contain relative paths`)
     }
 
@@ -201,7 +201,7 @@ class HardDriveDataProvider extends Provider {
     let fileName = params["fileName"]
 
     // Don't allow relative paths, let clients do that
-    if ([basePath, folderPath].join("/").indexOf("..") !== -1) {
+    if ([basePath, folderPath].join("/").indexOf("/..") !== -1) {
       throw new BadRequestError(`Folder paths must not contain relative paths`)
     }
 
@@ -225,7 +225,7 @@ class HardDriveDataProvider extends Provider {
     }
     if (body["path"]) {
       // Don't allow relative paths, let clients do that
-      if (body["path"].indexOf("..") !== -1) {
+      if (body["path"].indexOf("/..") !== -1) {
         throw new BadRequestError(`Folder paths must not contain relative paths`)
       }
       await fs.move(diskPath(basePath, folderPath, fileName), diskPath(basePath, body["path"], fileName), { overwrite: true })
@@ -262,14 +262,14 @@ class HardDriveDataProvider extends Provider {
     // Get the base path provided in the request body
     const basePath = body["base_path"]
     // Get the folder path in the URL
-    const folderPath = params["folderPath"]
+    const folderPath = params["folderPath"].replace(basePath, "")
     // Get the file name in the URL
     const fileName = params["fileName"]
 
     if (folderPath && fileName) {
       // If there is a file name provided, delete the file      
       // Don't allow relative paths, let clients do that
-      if ([basePath, folderPath].join("/").indexOf("..") !== -1) {
+      if ([basePath, folderPath].join("/").indexOf("/..") !== -1) {
         throw new BadRequestError(`Folder paths must not contain relative paths`)
       }
 
@@ -283,7 +283,7 @@ class HardDriveDataProvider extends Provider {
     } else if (folderPath && !fileName) {
       // If there is only a folder name provided, delete the folder and its contents
       // Don't allow relative paths, let clients do that
-      if ([basePath, folderPath].join("/").indexOf("..") !== -1) {
+      if ([basePath, folderPath].join("/").indexOf("/..") !== -1) {
         throw new BadRequestError(`Folder paths must not contain relative paths`)
       }
 

--- a/src/modules/one_drive.js
+++ b/src/modules/one_drive.js
@@ -58,7 +58,7 @@ class OneDriveDataProvider extends Provider {
     let {compareWith, operator, value, orderBy, direction, exportType} = queries
 
     // Don't allow relative paths, let clients do th
-    if (folderPath.indexOf("..") !== -1) {
+    if (folderPath.indexOf("/..") !== -1) {
       throw new BadRequestError(`Folder paths must not contain relative paths`)
     }
 
@@ -131,7 +131,7 @@ class OneDriveDataProvider extends Provider {
     const isShared = diskPath(params["folderPath"]).startsWith("/Shared") || diskPath(params["folderPath"]).startsWith("Shared")
 
     // Don't allow relative paths, let clients do that
-    if ([folderPath, fileName].join("/").indexOf("..") !== -1) {
+    if ([folderPath, fileName].join("/").indexOf("/..") !== -1) {
       throw new BadRequestError(`Folder paths must not contain relative paths`)
     }
 
@@ -190,7 +190,7 @@ class OneDriveDataProvider extends Provider {
     const exportType = body["exportType"]
 
     // Don't allow relative paths, let clients do that
-    if ([folderPath, fileName].join("/").indexOf("..") !== -1) {
+    if ([folderPath, fileName].join("/").indexOf("/..") !== -1) {
       throw new BadRequestError(`Folder paths must not contain relative paths`)
     }
 
@@ -282,7 +282,7 @@ class OneDriveDataProvider extends Provider {
     const exportType = body["exportType"]
 
     // Don't allow relative paths, let clients do that
-    if ([folderPath, fileName].join("/").indexOf("..") !== -1) {
+    if ([folderPath, fileName].join("/").indexOf("/..") !== -1) {
       throw new BadRequestError(`Folder paths must not contain relative paths`)
     }
 
@@ -313,7 +313,7 @@ class OneDriveDataProvider extends Provider {
     }
     if (body["path"]) {
       // Don't allow relative paths, let clients do that
-      if (body["path"].indexOf("..") !== -1) {
+      if (body["path"].indexOf("/..") !== -1) {
         throw new BadRequestError(`Folder paths must not contain relative paths`)
       }
       // Set the new parent on the file
@@ -390,7 +390,7 @@ class OneDriveDataProvider extends Provider {
     const fileName = params["fileName"]
 
     // Don't allow relative paths, let clients do that
-    if (folderPath.indexOf("..") !== -1) {
+    if (folderPath.indexOf("/..") !== -1) {
       throw new BadRequestError(`Folder paths must not contain relative paths`)
     }
 

--- a/src/server.js
+++ b/src/server.js
@@ -259,7 +259,7 @@ app.delete(`${rootURL}/data/:providerId/:folderPath/:fileName?`, (req, res, next
 
 // Retrieve a file/folder from cache
 app.get(`${rootURL}/cache/:filePath`, (req, res, next) => {
-  info(`(Get) Cached file requested with params: ${json(req.params)} and queries: ${json(req.query)}`)
+  info(`(Get) Get request called with params: ${json(req.params)} and queries: ${json(req.query)}`)
 
   if (req.params.filePath.includes("/..")) {
     throw new BadRequestError("File path may not contain ..")


### PR DESCRIPTION
**Describe the change:**
Adds an API call (GET) to retrieve files by their path within the .cache folder, gives a way for providers like Gmail to generate their own files and give a content URI. Also, the .cache folder is deleted on server close, so the file is stored only temporarily.

**Release notes:**
- add api to request files from cache
- remove start command required to start server, simply executing the file will work
- gmail: bundle files from gmail thread into zip
- fix relative path detection for providers
